### PR TITLE
Compatiblity with Firefox. Fixes #1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,4 +17,9 @@
 , "permissions":
   [ "storage"
   ]
+, "applications":
+  { "gecko":
+    { "id": "@GreenifyFacebook"
+    }
+  }
 }


### PR DESCRIPTION
For more information: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID#When_do_you_need_an_Add-on_ID

package to Firefox extension:
  `zip -r -FS ../GreenifyFacebook.xpi *`

To test in Firefox, open `about:debugging` > Load Temporary Add-on, and then choose your `GreenifyFacebook.xpi` file (or `manifest.json`)
